### PR TITLE
Remove spidergram.config.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -11,7 +11,3 @@ project_files:
 - docker-compose.arangodb.yaml
 - spidergram.config.yaml
 - config.ddev-spidergram.yaml
-
-post_install_actions:
-- |
-  mv ./spidergram.config.yaml ../spidergram.config.yaml


### PR DESCRIPTION
This currently installs a spidergram.config.yaml in the root of the repo. It shouldn't be doing that should it? That's a docker-compose file... that isn't being used?